### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A Model Context Protocol server that provides access to the current iTerm sessio
 
 iterm-mcp will execute commands in the currently active tab of iTerm. 
 
+<a href="https://glama.ai/mcp/servers/h89lr05ty6"><img width="380" height="200" src="https://glama.ai/mcp/servers/h89lr05ty6/badge" alt="iTerm Server MCP server" /></a>
+
 ### Tools
 - `execute_shell_command` - Executes a command in the current iTerm session
 


### PR DESCRIPTION
This PR adds a badge for the [iTerm MCP Server](https://glama.ai/mcp/servers/h89lr05ty6) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/h89lr05ty6"><img width="380" height="200" src="https://glama.ai/mcp/servers/h89lr05ty6/badge" alt="iTerm Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.