### PR TITLE
Remove command output parsing

### DIFF
--- a/src/CommandExecutor.ts
+++ b/src/CommandExecutor.ts
@@ -4,6 +4,7 @@ import { openSync, closeSync, appendFileSync, writeFileSync, existsSync } from '
 import { join } from 'node:path';
 import ProcessTracker from './ProcessTracker.js';
 import TtyOutputReader from './TtyOutputReader.js';
+import { after } from 'node:test';
 
 const execPromise = promisify(exec);
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
@@ -33,7 +34,8 @@ class CommandExecutor {
       await sleep(200);
       
       const afterCommandBuffer = await TtyOutputReader.retrieveBuffer();
-
+      return afterCommandBuffer;
+      
       // Extract only the new content by comparing buffers
       const output = this.extractCommandOutput(initialBuffer, afterCommandBuffer, command);
       

--- a/src/CommandExecutor.ts
+++ b/src/CommandExecutor.ts
@@ -14,10 +14,6 @@ class CommandExecutor {
     const escapedCommand = this.escapeForAppleScript(command);
     
     try {
-      // Retrieve the buffer before executing the command
-      const initialBuffer = await TtyOutputReader.retrieveBuffer();
-
-      // Using direct osascript command instead of a multi-line AppleScript
       await execPromise(`/usr/bin/osascript -e 'tell application "iTerm2" to tell current session of current window to write text "${escapedCommand}"'`);
       
       // Wait until iterm reports that processing is done
@@ -33,14 +29,8 @@ class CommandExecutor {
       // Give a small delay for output to settle
       await sleep(200);
       
-      const afterCommandBuffer = await TtyOutputReader.retrieveBuffer();
-      return afterCommandBuffer;
-      
-      // Extract only the new content by comparing buffers
-      const output = this.extractCommandOutput(initialBuffer, afterCommandBuffer, command);
-      
-      return output;
-
+      const afterCommandBuffer = await TtyOutputReader.retrieveBuffer()
+      return afterCommandBuffer
     } catch (error: unknown) {
       throw new Error(`Failed to execute command: ${(error as Error).message}`);
     }
@@ -108,89 +98,6 @@ class CommandExecutor {
     } catch (error: unknown) {
       throw new Error(`Failed to retrieve TTY path: ${(error as Error).message}`);
     }
-  }
-
-  private cleanTerminalOutput(buffer: string): string {
-    // Remove ANSI escape sequences
-    let cleaned = buffer.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
-    
-    // Handle carriage returns and line feeds properly
-    cleaned = cleaned.replace(/[^\n\r]+((\r+\n)|\r)[^\n\r]+/g, line => {
-      const parts = line.split(/\r+/);
-      return parts[parts.length - 1];
-    });
-
-    // Normalize line endings
-    cleaned = cleaned.replace(/\r\n/g, '\n');
-    
-    // Remove terminal control sequences
-    cleaned = cleaned.replace(/\x1b\][0-9;]*[a-zA-Z]/g, '');
-    
-    // Remove null characters
-    cleaned = cleaned.replace(/\x00/g, '');
-    
-    const result = cleaned.trim();
-    
-    return result;
-  }
-
-  private findCommandLine(lines: string[], command: string): number {
-    // Search from bottom up as the command might appear multiple times
-    for (let i = lines.length - 1; i >= 0; i--) {
-      const line = lines[i];
-      if (line.includes(command)) {
-        return i;
-      }
-    }
-    return -1;
-  }
-
-  private findNextPrompt(lines: string[], startIndex: number): number {
-    const promptPatterns = [
-      /[$#>]\s*$/,  // Basic shell prompts
-      /[a-zA-Z0-9_-]+@[a-zA-Z0-9_-]+:[~\w/]*[$#>]\s*$/  // Username@hostname style
-    ];
-
-    for (let i = startIndex; i < lines.length; i++) {
-      const line = lines[i].trim();
-      for (const pattern of promptPatterns) {
-        if (pattern.test(line)) {
-          return i;
-        }
-      }
-    }
-    return lines.length;
-  }
-
-  private extractCommandOutput(initialBuffer: string, afterBuffer: string, command: string): string {
-    // Clean both buffers
-    const cleanedInitial = this.cleanTerminalOutput(initialBuffer);
-    const cleanedAfter = this.cleanTerminalOutput(afterBuffer);
-
-    // Split into lines and remove empty lines
-    const initialLines = cleanedInitial.split('\n').filter(line => line.trim() !== '');
-    const afterLines = cleanedAfter.split('\n').filter(line => line.trim() !== '');
-
-    // Find the command line
-    const commandLineIndex = this.findCommandLine(afterLines, command);
-    if (commandLineIndex === -1) {
-      return '';
-    }
-
-    // Find the next prompt after the command
-    const nextPromptIndex = this.findNextPrompt(afterLines, commandLineIndex + 1);
-
-    // Extract everything between command and next prompt
-    const outputLines = afterLines.slice(commandLineIndex + 1, nextPromptIndex)
-      .filter(line => line.trim() !== '');  // Remove empty lines
-
-    // Remove any lines that exist in the initial buffer
-    const initialSet = new Set(initialLines);
-    const uniqueLines = outputLines.filter(line => !initialSet.has(line.trim()));
-
-    const result = uniqueLines.join('\n');
-    
-    return result;
   }
 
   private async isProcessing(): Promise<boolean> {

--- a/src/TtyOutputReader.ts
+++ b/src/TtyOutputReader.ts
@@ -4,10 +4,13 @@ import { promisify } from 'node:util';
 const execPromise = promisify(exec);
 
 export default class TtyOutputReader {
-  static async call(linesOfOutput: number) {
+  static async call(linesOfOutput?: number) {
     const buffer = await this.retrieveBuffer();
+    if (!linesOfOutput) {
+      return buffer;
+    }
     const lines = buffer.split('\n');
-    return lines.slice(-linesOfOutput - 1).join('\n'); // Include the last line
+    return lines.slice(-linesOfOutput - 1).join('\n');
   }
 
   static async retrieveBuffer(): Promise<string> {

--- a/src/TtyOutputReader.ts
+++ b/src/TtyOutputReader.ts
@@ -7,7 +7,7 @@ export default class TtyOutputReader {
   static async call(linesOfOutput: number) {
     const buffer = await this.retrieveBuffer();
     const lines = buffer.split('\n');
-    return lines.slice(-linesOfOutput).join('\n');
+    return lines.slice(-linesOfOutput - 1).join('\n'); // Include the last line
   }
 
   static async retrieveBuffer(): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const command = String(request.params.arguments?.command);
       const beforeCommandBuffer = await TtyOutputReader.retrieveBuffer();
       const beforeCommandBufferLines = beforeCommandBuffer.split("\n").length;
+      
       await executor.executeCommand(command);
+      
       const afterCommandBuffer = await TtyOutputReader.retrieveBuffer();
       const afterCommandBufferLines = afterCommandBuffer.split("\n").length;
       const outputLines = afterCommandBufferLines - beforeCommandBufferLines
@@ -86,7 +88,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return {
         content: [{
           type: "text",
-          text: `The command was sent to the terminal. ${outputLines} lines were output after sending the command to the terminal. Read the last ${outputLines} lines of terminal contents to orient yourself.`
+          text: `${outputLines} lines were output after sending the command to the terminal. Read the last ${outputLines} lines of terminal contents to orient yourself. Never assume that the command was executed or that it was successful.`
         }]
       };
     }

--- a/test/CommandExecutor.test.ts
+++ b/test/CommandExecutor.test.ts
@@ -7,19 +7,17 @@ async function testExecuteCommand() {
   const command = process.argv.slice(2).join(' ') || 'date';
   
   try {
-    //const output = await executor.executeCommand(command);
-    //console.log('Command Output:', output);
-    //const outputLines = output.split("\n").length;
-    
     const beforeCommandBuffer = await TtyOutputReader.retrieveBuffer();
     const beforeCommandBufferLines = beforeCommandBuffer.split("\n").length;
+
     await executor.executeCommand(command);
+
     const afterCommandBuffer = await TtyOutputReader.retrieveBuffer();
     const afterCommandBufferLines = afterCommandBuffer.split("\n").length;
     const outputLines = afterCommandBufferLines - beforeCommandBufferLines
     
-    const stuff = await TtyOutputReader.call(outputLines)
-    console.log(stuff);
+    const buffer = await TtyOutputReader.call(outputLines)
+    console.log(buffer);
 
     console.log(`Lines: ${outputLines}`);
   } catch (error) {

--- a/test/CommandExecutor.test.ts
+++ b/test/CommandExecutor.test.ts
@@ -1,4 +1,5 @@
 import CommandExecutor from '../src/CommandExecutor.js';
+import TtyOutputReader from '../src/TtyOutputReader.js';
 
 async function testExecuteCommand() {
   const executor = new CommandExecutor();
@@ -6,11 +7,26 @@ async function testExecuteCommand() {
   const command = process.argv.slice(2).join(' ') || 'date';
   
   try {
-    const output = await executor.executeCommand(command);
-    console.log('Command Output:', output);
+    //const output = await executor.executeCommand(command);
+    //console.log('Command Output:', output);
+    //const outputLines = output.split("\n").length;
+    
+    const beforeCommandBuffer = await TtyOutputReader.retrieveBuffer();
+    const beforeCommandBufferLines = beforeCommandBuffer.split("\n").length;
+    await executor.executeCommand(command);
+    const afterCommandBuffer = await TtyOutputReader.retrieveBuffer();
+    const afterCommandBufferLines = afterCommandBuffer.split("\n").length;
+    const outputLines = afterCommandBufferLines - beforeCommandBufferLines
+    
+    const stuff = await TtyOutputReader.call(outputLines)
+    console.log(stuff);
+
+    console.log(`Lines: ${outputLines}`);
   } catch (error) {
     console.error('Error executing command:', (error as Error).message);
   }
+
+  
 }
 
 testExecuteCommand();


### PR DESCRIPTION
This PR changes how the model interacts with the terminal once iterm-mcp determines that the terminal is waiting for input. 

Before:
iterm-mcp would attempt to parse the terminal buffer and return what iterm-mcp determined to be the output of the command. This was great in most cirucmstances, but it fails hard on edge cases leaving the model unsure of what's going on.

After:
No command output parsing takes place. The command is sent to iTerm, and the model is informed how many lines were output from the command. The model is forced to retrieve the terminal buffer after executing the command. This helps situations where the command hasn't yet completed, or the command has left the terminal in an unexpected state (a pager for example).