### PR TITLE
Update `read_terminal_output` to use `integer` type for parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           type: "object",
           properties: {
             linesOfOutput: {
-              type: "number",
+              type: "integer",
               description: "The number of lines of output to read."
             },
           },


### PR DESCRIPTION
For MCP clients that offer different UI controls for `number` / `integer`, I believe that `integer` may be a better JSONSchema type here: https://json-schema.org/understanding-json-schema/reference/numeric