### PR TITLE
Fix multiline text handling in AppleScript commands

### DIFF
--- a/docs/multiline-fix.md
+++ b/docs/multiline-fix.md
@@ -1,0 +1,49 @@
+# Multiline Text Support in iTerm MCP Extension
+
+## Issue Summary
+
+When sending multiline text through the MCP to iTerm2, the operation was failing with a syntax error. This affected basic operations like using text editors (nano, micro, vim), creating files with multiple lines, and working with remote servers via SSH.
+
+## Error Message
+
+```
+Failed to call tool write_to_terminal: Error: MCP error -32603:
+Failed to execute command: Command failed: /usr/bin/osascript -e
+'tell application "iTerm2"...syntax error: Expected """ but found unknown token. (-2741)
+```
+
+## Root Cause
+
+The issue was in the `escapeForAppleScript` method in the `CommandExecutor.ts` file. The method did not properly handle newlines in the AppleScript command. When newlines were present in the text, they would break the AppleScript string syntax, resulting in a syntax error.
+
+## Solution
+
+We implemented a solution that:
+
+1. Detects when a command contains newlines
+2. For multiline text, uses a different AppleScript approach that properly handles line breaks
+3. For single-line text, continues to use the original approach with simple string escaping
+
+The key part of the solution is using AppleScript's string concatenation with explicit return statements instead of trying to embed newlines directly in the AppleScript string.
+
+### Implementation Details
+
+1. Modified `escapeForAppleScript` to detect multiline text and handle it differently
+2. Added a `prepareMultilineCommand` method that:
+   - Splits the input by newlines
+   - Creates an AppleScript string expression that concatenates each line with return statements
+   - Uses AppleScript's `&` operator to concatenate strings with `return` between them
+3. Added an `escapeAppleScriptString` method to properly escape special characters in each line
+4. Updated `executeCommand` to use different AppleScript syntax based on whether the command contains newlines
+
+## Usage
+
+No changes to the existing API are required. The fix is implemented transparently, so clients can continue to use the extension the same way as before, but now with support for multiline content.
+
+## Testing
+
+A test file (`test/MultilineTest.ts`) was created to verify the fix works correctly with multiline text.
+
+## Future Considerations
+
+This approach should handle most multiline text scenarios, but there may be edge cases with very complex text containing special characters and newlines. If those arise, further refinements to the escaping logic may be needed.

--- a/src/CommandExecutor.ts
+++ b/src/CommandExecutor.ts
@@ -6,21 +6,51 @@ import ProcessTracker from './ProcessTracker.js';
 import TtyOutputReader from './TtyOutputReader.js';
 import { after } from 'node:test';
 
+/**
+ * CommandExecutor handles sending commands to iTerm2 via AppleScript.
+ * 
+ * This includes special handling for multiline text to prevent AppleScript syntax errors
+ * when dealing with newlines in command strings. The approach uses AppleScript string 
+ * concatenation with explicit line breaks rather than trying to embed newlines directly
+ * in the AppleScript string.
+ */
+
 const execPromise = promisify(exec);
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 class CommandExecutor {
+  /**
+   * Executes a command in the iTerm2 terminal.
+   * 
+   * This method handles both single-line and multiline commands by:
+   * 1. Properly escaping the command string for AppleScript
+   * 2. Using different AppleScript approaches based on whether the command contains newlines
+   * 3. Waiting for the command to complete execution
+   * 4. Retrieving the terminal output after command execution
+   * 
+   * @param command The command to execute (can contain newlines)
+   * @returns A promise that resolves to the terminal output after command execution
+   */
   async executeCommand(command: string): Promise<string> {
     const escapedCommand = this.escapeForAppleScript(command);
     
     try {
-      await execPromise(`/usr/bin/osascript -e 'tell application "iTerm2" to tell current session of current window to write text "${escapedCommand}"'`);
+      // Check if this is a multiline command (which would have been processed differently)
+      if (command.includes('\n')) {
+        // For multiline text, we use parentheses around our prepared string expression
+        // This allows AppleScript to evaluate the string concatenation expression
+        await execPromise(`/usr/bin/osascript -e 'tell application "iTerm2" to tell current session of current window to write text (${escapedCommand})'`);
+      } else {
+        // For single line commands, we can use the standard approach with quoted strings
+        await execPromise(`/usr/bin/osascript -e 'tell application "iTerm2" to tell current session of current window to write text "${escapedCommand}"'`);
+      }
       
-      // Wait until iterm reports that processing is done
+      // Wait until iTerm2 reports that command processing is complete
       while (await this.isProcessing()) {
         await sleep(100);
       }
       
+      // Get the TTY path and check if it's waiting for user input
       const ttyPath = await this.retrieveTtyPath();
       while (await this.isWaitingForUserInput(ttyPath) === false) {
         await sleep(100);
@@ -29,6 +59,7 @@ class CommandExecutor {
       // Give a small delay for output to settle
       await sleep(200);
       
+      // Retrieve the terminal output after command execution
       const afterCommandBuffer = await TtyOutputReader.retrieveBuffer()
       return afterCommandBuffer
     } catch (error: unknown) {
@@ -73,7 +104,25 @@ class CommandExecutor {
     }
   }
 
+  /**
+   * Escapes a string for use in an AppleScript command.
+   * 
+   * This method handles two scenarios:
+   * 1. For multiline text (containing newlines), it uses a special AppleScript
+   *    string concatenation approach to properly handle line breaks
+   * 2. For single-line text, it escapes special characters for AppleScript compatibility
+   * 
+   * @param str The string to escape
+   * @returns A properly escaped string ready for AppleScript execution
+   */
   private escapeForAppleScript(str: string): string {
+    // Check if the string contains newlines
+    if (str.includes('\n')) {
+      // For multiline text, we need to use a different AppleScript approach
+      // that properly handles newlines in AppleScript
+      return this.prepareMultilineCommand(str);
+    }
+    
     // First, escape any backslashes
     str = str.replace(/\\/g, '\\\\');
     
@@ -83,12 +132,60 @@ class CommandExecutor {
     // Handle single quotes by breaking out of the quote, escaping the quote, and going back in
     str = str.replace(/'/g, "'\\''");
     
-    // Handle special characters
+    // Handle special characters (except newlines which are handled separately)
     str = str.replace(/[^\x20-\x7E]/g, (char) => {
       return '\\u' + char.charCodeAt(0).toString(16).padStart(4, '0');
     });
     
     return str;
+  }
+  
+  /**
+   * Prepares a multiline string for use in AppleScript.
+   * 
+   * This method handles multiline text by splitting it into separate lines
+   * and creating an AppleScript expression that concatenates these lines
+   * with explicit 'return' statements between them. This approach avoids
+   * syntax errors that occur when trying to directly include newlines in
+   * AppleScript strings.
+   * 
+   * @param str The multiline string to prepare
+   * @returns An AppleScript-compatible string expression that preserves line breaks
+   */
+  private prepareMultilineCommand(str: string): string {
+    // Split the input by newlines and prepare each line separately
+    const lines = str.split('\n');
+    
+    // Create an AppleScript string that concatenates all lines with proper line breaks
+    let applescriptString = '"' + this.escapeAppleScriptString(lines[0]) + '"';
+    
+    for (let i = 1; i < lines.length; i++) {
+      // For each subsequent line, use AppleScript's string concatenation with line feed
+      // The 'return' keyword in AppleScript adds a newline character
+      applescriptString += ' & return & "' + this.escapeAppleScriptString(lines[i]) + '"'; 
+    }
+    
+    return applescriptString;
+  }
+  
+  /**
+   * Escapes a single line of text for use in an AppleScript string.
+   * 
+   * Handles special characters that would otherwise cause syntax errors
+   * in AppleScript strings:
+   * - Backslashes are doubled to avoid escape sequence interpretation
+   * - Double quotes are escaped to avoid prematurely terminating the string
+   * - Tabs are replaced with their escape sequence
+   * 
+   * @param str The string to escape (should not contain newlines)
+   * @returns The escaped string
+   */
+  private escapeAppleScriptString(str: string): string {
+    // Escape quotes and backslashes for AppleScript string
+    return str
+      .replace(/\\/g, '\\\\')  // Double backslashes
+      .replace(/"/g, '\\"')    // Escape double quotes
+      .replace(/\t/g, '\\t');  // Handle tabs
   }
 
   private async retrieveTtyPath(): Promise<string> {

--- a/test/MultilineTest.ts
+++ b/test/MultilineTest.ts
@@ -1,0 +1,41 @@
+import CommandExecutor from '../build/CommandExecutor.js';
+import TtyOutputReader from '../build/TtyOutputReader.js';
+
+async function testMultilineCommand() {
+  const executor = new CommandExecutor();
+  
+  // Create a multiline command
+  const multilineText = `Line 1
+Line 2
+Line 3
+Line 4
+This is a test of the multiline functionality.`;
+  
+  try {
+    console.log("Testing multiline command handling...");
+    console.log("Sending multiline text:");
+    console.log("---");
+    console.log(multilineText);
+    console.log("---");
+    
+    const beforeCommandBuffer = await TtyOutputReader.retrieveBuffer();
+    const beforeCommandBufferLines = beforeCommandBuffer.split("\n").length;
+
+    await executor.executeCommand(multilineText);
+
+    const afterCommandBuffer = await TtyOutputReader.retrieveBuffer();
+    const afterCommandBufferLines = afterCommandBuffer.split("\n").length;
+    const outputLines = afterCommandBufferLines - beforeCommandBufferLines;
+    
+    console.log(`Result: ${outputLines} new lines were output`);
+    
+    const buffer = await TtyOutputReader.call(20);
+    console.log("Last 20 lines of output:");
+    console.log(buffer);
+    
+  } catch (error) {
+    console.error('Error executing multiline command:', (error as Error).message);
+  }
+}
+
+testMultilineCommand();

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".."
+  },
+  "include": ["**/*", "../src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,11 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
+    "checkJs": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "test"]
 }


### PR DESCRIPTION
# Multiline Text Support in iTerm MCP Extension

## Issue Summary

When sending multiline text through the MCP to iTerm2, the operation was failing with a syntax error. This affected basic operations like using text editors (nano, micro, vim), creating files with multiple lines, and working with remote servers via SSH.

## Error Message

```
Failed to call tool write_to_terminal: Error: MCP error -32603:
Failed to execute command: Command failed: /usr/bin/osascript -e
'tell application "iTerm2"...syntax error: Expected """ but found unknown token. (-2741)
```

## Root Cause

The issue was in the `escapeForAppleScript` method in the `CommandExecutor.ts` file. The method did not properly handle newlines in the AppleScript command. When newlines were present in the text, they would break the AppleScript string syntax, resulting in a syntax error.

## Solution

We implemented a solution that:

1. Detects when a command contains newlines
2. For multiline text, uses a different AppleScript approach that properly handles line breaks
3. For single-line text, continues to use the original approach with simple string escaping

The key part of the solution is using AppleScript's string concatenation with explicit return statements instead of trying to embed newlines directly in the AppleScript string.

### Implementation Details

1. Modified `escapeForAppleScript` to detect multiline text and handle it differently
2. Added a `prepareMultilineCommand` method that:
   - Splits the input by newlines
   - Creates an AppleScript string expression that concatenates each line with return statements
   - Uses AppleScript's `&` operator to concatenate strings with `return` between them
3. Added an `escapeAppleScriptString` method to properly escape special characters in each line
4. Updated `executeCommand` to use different AppleScript syntax based on whether the command contains newlines

## Usage

No changes to the existing API are required. The fix is implemented transparently, so clients can continue to use the extension the same way as before, but now with support for multiline content.

## Testing

A test file (`test/MultilineTest.ts`) was created to verify the fix works correctly with multiline text.

## Future Considerations

This approach should handle most multiline text scenarios, but there may be edge cases with very complex text containing special characters and newlines. If those arise, further refinements to the escaping logic may be needed.