### PR TITLE
Add 'wait' parameter to write_to_terminal for TUI app testing

### DIFF
--- a/src/CommandExecutor.ts
+++ b/src/CommandExecutor.ts
@@ -33,9 +33,10 @@ class CommandExecutor {
    * 4. Retrieving the terminal output after command execution
    * 
    * @param command The command to execute (can contain newlines)
+   * @param wait Whether to wait for the command to finish executing (useful for TUI applications)
    * @returns A promise that resolves to the terminal output after command execution
    */
-  async executeCommand(command: string): Promise<string> {
+  async executeCommand(command: string, wait: boolean): Promise<string> {
     const escapedCommand = this.escapeForAppleScript(command);
     
     try {
@@ -50,13 +51,13 @@ class CommandExecutor {
       }
       
       // Wait until iTerm2 reports that command processing is complete
-      while (await this.isProcessing()) {
+      while (wait && await this.isProcessing()) {
         await sleep(100);
       }
       
       // Get the TTY path and check if it's waiting for user input
       const ttyPath = await this.retrieveTtyPath();
-      while (await this.isWaitingForUserInput(ttyPath) === false) {
+      while (wait && await this.isWaitingForUserInput(ttyPath) === false) {
         await sleep(100);
       }
 

--- a/src/CommandExecutor.ts
+++ b/src/CommandExecutor.ts
@@ -33,7 +33,7 @@ class CommandExecutor {
    * 4. Retrieving the terminal output after command execution
    * 
    * @param command The command to execute (can contain newlines)
-   * @param wait Whether to wait for the command to finish executing (useful for TUI applications)
+   * @param wait Whether to wait for the command to finish executing (false is useful for TUI applications)
    * @returns A promise that resolves to the terminal output after command execution
    */
   async executeCommand(command: string, wait: boolean): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             wait: {
               type: "boolean",
-              description: "Whether to wait for the command to finish executing (useful for TUI applications)"
+              description: "Whether to wait for the command to finish executing (default: true, false is useful for TUI applications)",
+              default: true
             },
           },
           required: ["command"]
@@ -80,7 +81,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case "write_to_terminal": {
       let executor = new CommandExecutor();
       const command = String(request.params.arguments?.command);
-      const wait = Boolean(request.params.arguments?.wait);
+      const wait = request.params.arguments?.wait !== undefined ? Boolean(request.params.arguments?.wait) : true;
       const beforeCommandBuffer = await TtyOutputReader.retrieveBuffer();
       const beforeCommandBufferLines = beforeCommandBuffer.split("\n").length;
       

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: "string",
               description: "The command to run or text to write to the terminal"
             },
+            wait: {
+              type: "boolean",
+              description: "Whether to wait for the command to finish executing (useful for TUI applications)"
+            },
           },
           required: ["command"]
         }
@@ -76,10 +80,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case "write_to_terminal": {
       let executor = new CommandExecutor();
       const command = String(request.params.arguments?.command);
+      const wait = Boolean(request.params.arguments?.wait);
       const beforeCommandBuffer = await TtyOutputReader.retrieveBuffer();
       const beforeCommandBufferLines = beforeCommandBuffer.split("\n").length;
       
-      await executor.executeCommand(command);
+      await executor.executeCommand(command, wait);
       
       const afterCommandBuffer = await TtyOutputReader.retrieveBuffer();
       const afterCommandBufferLines = afterCommandBuffer.split("\n").length;


### PR DESCRIPTION
## Summary
- Added optional 'wait' parameter to write_to_terminal tool (defaults to true)
- Enables testing of TUI applications that don't exit automatically
- Allows interaction with long-running terminal applications

## Test plan
- [x] Test with TUI applications that require user interaction
- [x] Ensure terminal control is properly returned after wait period