### PR TITLE
add cmd to write and wait for output to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ A Model Context Protocol server that provides access to your iTerm session.
 - `write_to_terminal` - Writes to the active iTerm terminal, often used to run a command. Returns the number of lines of output produced by the command.
 - `read_terminal_output` - Reads the requested number of lines from the active iTerm terminal.
 - `send_control_character` - Sends a control character to the active iTerm terminal.
+- `write_and_read_terminal` - Executes a command and returns the terminal output in a single operation. Useful when you need both execution and output in one step.
+
+> **Note:** Some agents may default to using `write_to_terminal` and `read_terminal_output` separately. You may need to configure your agent (via system prompt or rules) to prefer `write_and_read_terminal` for a smoother single-step experience.
 
 ### Requirements
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,24 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ["letter"]
         }
+      },
+      {
+        name: "write_and_read_terminal",
+        description: "Execute a command and return the terminal output after completion",
+        inputSchema: {
+          type: "object",
+          properties: {
+            command: {
+              type: "string",
+              description: "The command to execute"
+            },
+            linesOfOutput: {
+              type: "integer",
+              description: "Number of lines to read (default: 50)"
+            }
+          },
+          required: ["command"]
+        }
       }
     ]
   };
@@ -112,6 +130,24 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         content: [{
           type: "text",
           text: `Sent control character: Control-${letter.toUpperCase()}`
+        }]
+      };
+    }
+    case "write_and_read_terminal": {
+      const executor = new CommandExecutor();
+      const command = String(request.params.arguments?.command);
+      const linesOfOutput = Number(request.params.arguments?.linesOfOutput) || 50;
+
+      // Execute command (waits for completion internally)
+      await executor.executeCommand(command);
+
+      // Read and return output
+      const output = await TtyOutputReader.call(linesOfOutput);
+
+      return {
+        content: [{
+          type: "text",
+          text: output
         }]
       };
     }

--- a/test/unit/WriteAndReadTerminal.test.ts
+++ b/test/unit/WriteAndReadTerminal.test.ts
@@ -1,0 +1,97 @@
+// @ts-nocheck
+/**
+ * Tests for the write_and_read_terminal tool handler logic.
+ */
+const mockExecPromiseFn = jest.fn();
+
+jest.mock('node:util', () => ({
+  promisify: jest.fn().mockReturnValue(mockExecPromiseFn)
+}));
+jest.mock('node:child_process', () => ({
+  exec: jest.fn()
+}));
+jest.mock('../../src/TtyOutputReader.js', () => ({
+  __esModule: true,
+  default: {
+    retrieveBuffer: jest.fn().mockResolvedValue('Mocked terminal output'),
+    call: jest.fn().mockResolvedValue('Mocked output lines')
+  }
+}));
+jest.mock('node:fs', () => ({
+  openSync: jest.fn().mockReturnValue(1),
+  closeSync: jest.fn(),
+  existsSync: jest.fn().mockReturnValue(true)
+}));
+
+import { jest, describe, expect, test, beforeEach } from '@jest/globals';
+
+describe('write_and_read_terminal tool', () => {
+  let CommandExecutor;
+  let commandExecutor;
+  let TtyOutputReader;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    // Dynamically import after mocks
+    CommandExecutor = (await import('../../src/CommandExecutor.js')).default;
+    TtyOutputReader = (await import('../../src/TtyOutputReader.js')).default;
+    jest.spyOn(TtyOutputReader, 'retrieveBuffer').mockResolvedValue('Mocked terminal output');
+    jest.spyOn(TtyOutputReader, 'call').mockResolvedValue('Mocked output lines');
+    mockExecPromiseFn.mockImplementation((command) => {
+      if (command.includes('get tty')) {
+        return Promise.resolve({ stdout: '/dev/ttys000\n', stderr: '' });
+      } else if (command.includes('get is processing')) {
+        return Promise.resolve({ stdout: 'false\n', stderr: '' });
+      } else {
+        return Promise.resolve({ stdout: '', stderr: '' });
+      }
+    });
+    // Inject the mockExecPromiseFn into CommandExecutor
+    commandExecutor = new CommandExecutor(mockExecPromiseFn);
+  });
+
+  test('executes command and reads output (simulating tool handler)', async () => {
+    const testCommand = 'echo "test" && date';
+    const expectedOutput = 'test\nTue Dec 23 10:29:37 CST 2025';
+    jest.spyOn(TtyOutputReader, 'call').mockResolvedValue(expectedOutput);
+
+    // Simulate what the write_and_read_terminal tool handler does:
+    // 1. Execute command (waits for completion)
+    await commandExecutor.executeCommand(testCommand);
+    
+    // 2. Read and return output
+    const linesOfOutput = 50;
+    const output = await TtyOutputReader.call(linesOfOutput);
+
+    // Verify command was sent to iTerm
+    const writeTextCall = mockExecPromiseFn.mock.calls.find(call =>
+      call[0].includes('write text') && call[0].includes('echo')
+    );
+    expect(writeTextCall).toBeTruthy();
+    
+    // Verify output was read with correct line count
+    expect(TtyOutputReader.call).toHaveBeenCalledWith(50);
+    expect(output).toBe(expectedOutput);
+  });
+
+  test('uses default linesOfOutput of 50 when not specified', async () => {
+    await commandExecutor.executeCommand('test');
+    
+    // Simulate the default parameter logic: Number(undefined) || 50
+    const linesOfOutput = Number(undefined) || 50;
+    await TtyOutputReader.call(linesOfOutput);
+
+    expect(TtyOutputReader.call).toHaveBeenCalledWith(50);
+  });
+
+  test('uses custom linesOfOutput when specified', async () => {
+    await commandExecutor.executeCommand('test');
+    
+    // Simulate custom parameter: Number(100) || 50
+    const linesOfOutput = Number(100) || 50;
+    await TtyOutputReader.call(linesOfOutput);
+
+    expect(TtyOutputReader.call).toHaveBeenCalledWith(100);
+  });
+});
+


### PR DESCRIPTION
I'd like to be able to give 1 permission to write and read the output of a terminal command.

- added `write_and_read_terminal` command to allow for single permission
- added unit test for new behavior
- updated README
